### PR TITLE
Updated hash for tarball for new version of PyCm

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
    url: http://software.igwn.org/lscsoft/source/{{ name }}-{{ version }}.tar.gz
-   sha256: fe2c903b7bf5dfb72cf5ec163f6b934a4af0515075654d7dfd29d568c985f9ee
+   sha256: c6c69f3ceaab753a2f4281c6b11d22d46b4154b7bb55df365b6bbfe54d9ade99
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
    sha256: c6c69f3ceaab753a2f4281c6b11d22d46b4154b7bb55df365b6bbfe54d9ade99
 
 build:
-  number: 1
+  number: 2
   skip: true  # [not linux]
 
 requirements:


### PR DESCRIPTION
The new tarball has CMake pass the location of the c compiler to ctypesgen so the c compiler is always found. This is required because ctypesgen would default to `gcc` which is not always available (especially in a conda environment)

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
