### PR TITLE
Bug fix to String function in ctypesgen header

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pycm" %}
-{% set version = "7.5.2" %}
+{% set version = "7.5.3" %}
 
 package:
    name: "{{ name }}"
@@ -7,10 +7,10 @@ package:
 
 source:
    url: http://software.igwn.org/lscsoft/source/{{ name }}-{{ version }}.tar.gz
-   sha256: c6c69f3ceaab753a2f4281c6b11d22d46b4154b7bb55df365b6bbfe54d9ade99
+   sha256: 19c84db4aa034734ce0655d8ca9036d9c02d916357869b5bd4e79a86c0e9960a
 
 build:
-  number: 2
+  number: 0
   skip: true  # [not linux]
 
 requirements:


### PR DESCRIPTION
The String function requires a bytes-type, but the default is a
string so this needed to be changed so the default is a bytestring.
This was no issue in with this python2 since bytestring and strings
 were treated the same, but in python3 strings and bytestrings are
 treated differently causing the issue that this pull request fixes.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
