### PR TITLE
Moved to new version of PyCm

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pycm" %}
-{% set version = "7.5.3" %}
+{% set version = "7.5.4" %}
 
 package:
    name: "{{ name }}"
@@ -7,7 +7,7 @@ package:
 
 source:
    url: http://software.igwn.org/lscsoft/source/{{ name }}-{{ version }}.tar.gz
-   sha256: 19c84db4aa034734ce0655d8ca9036d9c02d916357869b5bd4e79a86c0e9960a
+   sha256: 73ef3cfae95c065e36e71d3b99497c1563b054934fe91889724377ba35fb7965
 
 build:
   number: 0


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Added in elif to string class in ctypes binding to allow strings

In Python2 the String class could be initialised using string type, since python2 does not differentiate between string and bytestring. But this is no longer true in python3, so the String function needs to be updated to enable strings to be parsed